### PR TITLE
feat: add Profile link to nav and footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -689,6 +689,7 @@
       </a>
       <div class="nav-links">
         <a href="https://corvid-agent.github.io">Home</a>
+        <a href="https://corvid-agent.github.io/agent-profile/" style="color: var(--text-bright);">Profile</a>
         <a href="https://corvid-agent.github.io/agent-dashboard/">Dashboard</a>
         <a href="https://corvid-agent.github.io/algo-explorer/">Explorer</a>
         <a href="https://corvid-agent.github.io/corvid-agent-chat/">Chat</a>
@@ -891,6 +892,7 @@
     <footer class="footer">
       <div style="display: flex; justify-content: center; gap: 1.5rem; margin-bottom: 1.2rem; flex-wrap: wrap;">
         <a href="https://corvid-agent.github.io/" style="color: var(--text-dim); text-decoration: none; font-size: 0.82rem;">Home</a>
+        <a href="https://corvid-agent.github.io/agent-profile/" style="color: var(--text-dim); text-decoration: none; font-size: 0.82rem;">Profile</a>
         <a href="https://corvid-agent.github.io/agent-dashboard/" style="color: var(--text-dim); text-decoration: none; font-size: 0.82rem;">Dashboard</a>
         <a href="https://corvid-agent.github.io/algo-explorer/" style="color: var(--text-dim); text-decoration: none; font-size: 0.82rem;">Explorer</a>
         <a href="https://corvid-agent.github.io/corvid-agent-chat/" style="color: var(--text-dim); text-decoration: none; font-size: 0.82rem;">Chat</a>


### PR DESCRIPTION
## Summary
- Add self-referencing "Profile" link to the nav bar (with active styling)
- Add "Profile" link to the footer nav for complete ecosystem consistency

## Consistency
All ecosystem sites now have the same 7 links: Home, Profile, Dashboard, Explorer, Chat, Cinema, GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)